### PR TITLE
Check scheme and exit

### DIFF
--- a/cgit-wp-https-redirect.php
+++ b/cgit-wp-https-redirect.php
@@ -15,6 +15,7 @@ License: MIT
 if (!isHttps() && optionsUrlIsHttps() && !isBlocked()) {
     header("HTTP/1.1 301 Moved Permanently");
     header('Location: https://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI']);
+    exit();
 }
 
 /**
@@ -24,7 +25,8 @@ if (!isHttps() && optionsUrlIsHttps() && !isBlocked()) {
  */
 function isHttps()
 {
-    return isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on';
+    return (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ||
+        (isset($_SERVER['REQUEST_SCHEME']) && $_SEVER['REQUEST_SCHEME']=='https');
 }
 
 /**


### PR DESCRIPTION
I deployed this on a server environment that wasn't sending HTTP in the server superglobal, so I've added what that one was sending as well. Also the redirect wasn't working unless I exited after sending it.